### PR TITLE
Add static NAT resource

### DIFF
--- a/cloudca/README.md
+++ b/cloudca/README.md
@@ -6,6 +6,7 @@
 - [**cloudca_network_acl_rule**](#cloudca_network_acl_rule)
 - [**cloudca_instance**](#cloudca_instance)
 - [**cloudca_public_ip**](#cloudca_public_ip)
+- [**cloudca_static_nat**](#cloudca_static_nat)
 - [**cloudca_port_forwarding_rule**](#cloudca_port_forwarding_rule)
 - [**cloudca_volume**](#cloudca_volume)
 
@@ -205,6 +206,26 @@ The following arguments are supported:
 ### Attribute Reference
 - id - The public IP ID.
 - ip_address - The public IP address
+
+## cloudca_static_nat
+Configures static NAT between a public and a private IP. Enabling static NAT is equivalent to forwarding every public port to every private port.
+
+### Example usage
+```hcl
+resource "cloudca_static_nat" "dev_static_nat" {
+	service_code     = "compute-qc"
+	environment_name = "dev"
+
+	public_ip_id     = "10d523c1-907a-4f85-9181-9d62b16851c9"
+	private_ip_id    = "c0d9824b-cb83-45ca-baca-e7e6c63a96a8"
+}
+```
+
+### Argument reference
+- service_code - (Required)
+- environment_name - (Required)
+- public_ip_id - (Required) The public IP to configure static NAT on. Cannot have any other purpose (e.g. load balancing, port forwarding)
+- private_ip_id - (Required) The private IP to configure static NAT on. Must be in the same VPC as the public IP
 
 ## cloudca_port_forwarding_rule
 Manages port forwarding rules. Modifying any field will result in destruction and recreation of the rule.

--- a/cloudca/README.md
+++ b/cloudca/README.md
@@ -208,7 +208,7 @@ The following arguments are supported:
 - ip_address - The public IP address
 
 ## cloudca_static_nat
-Configures static NAT between a public and a private IP. Enabling static NAT is equivalent to forwarding every public port to every private port.
+Configures static NAT between a public and a private IP of an instance. Enabling static NAT is equivalent to forwarding every public port to every private port.
 
 ### Example usage
 ```hcl
@@ -225,7 +225,7 @@ resource "cloudca_static_nat" "dev_static_nat" {
 - service_code - (Required)
 - environment_name - (Required)
 - public_ip_id - (Required) The public IP to configure static NAT on. Cannot have any other purpose (e.g. load balancing, port forwarding)
-- private_ip_id - (Required) The private IP to configure static NAT on. Must be in the same VPC as the public IP
+- private_ip_id - (Required) A private IP of the instance to configure static NAT on. Must be in the same VPC as the public IP. Secondary IPs can be used here
 
 ## cloudca_port_forwarding_rule
 Manages port forwarding rules. Modifying any field will result in destruction and recreation of the rule.

--- a/cloudca/resource_cloudca.go
+++ b/cloudca/resource_cloudca.go
@@ -1,9 +1,13 @@
 package cloudca
 
 import (
+	"github.com/cloud-ca/go-cloudca"
+	"github.com/cloud-ca/go-cloudca/services/cloudca"
+	"github.com/cloud-ca/go-cloudca/api"
 	"github.com/hashicorp/terraform/helper/schema"
 	"regexp"
 	"strconv"
+	"fmt"
 )
 
 func GetCloudCAResourceMap() map[string]*schema.Resource {
@@ -17,6 +21,7 @@ func GetCloudCAResourceMap() map[string]*schema.Resource {
 		"cloudca_volume":               resourceCloudcaVolume(),
 		"cloudca_network_acl":          resourceCloudcaNetworkAcl(),
 		"cloudca_network_acl_rule":     resourceCloudcaNetworkAclRule(),
+		"cloudca_static_nat":           resourceCloudcaStaticNat(),
 	}
 }
 
@@ -39,4 +44,23 @@ func readIntFromString(valStr string) int {
 		valInt, _ = strconv.Atoi(valStr)
 	}
 	return valInt
+}
+
+// Provides a common, simple way to deal with 404s.
+func handleNotFoundError(err error, d *schema.ResourceData) error {
+	if ccaError, ok := err.(api.CcaErrorResponse); ok {
+		if ccaError.StatusCode == 404 {
+			fmt.Errorf("Entity (id=%s) not found", d.Id())
+			d.SetId("")
+			return nil
+		}
+	}
+	return err
+}
+
+// Deals with all of the casting done to get a cloudca.Resources.
+func getResources(d *schema.ResourceData, meta interface{}) cloudca.Resources {
+	client := meta.(*cca.CcaClient)
+	_resources, _ := client.GetResources(d.Get("service_code").(string), d.Get("environment_name").(string))
+	return _resources.(cloudca.Resources)
 }

--- a/cloudca/resource_cloudca_port_forwarding_rule.go
+++ b/cloudca/resource_cloudca_port_forwarding_rule.go
@@ -1,9 +1,7 @@
 package cloudca
 
 import (
-	"fmt"
 	"github.com/cloud-ca/go-cloudca"
-	"github.com/cloud-ca/go-cloudca/api"
 	"github.com/cloud-ca/go-cloudca/services/cloudca"
 	"github.com/hashicorp/terraform/helper/schema"
 	"strconv"
@@ -155,16 +153,4 @@ func deletePortForwardingRule(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d)
 	}
 	return nil
-}
-
-func handleNotFoundError(err error, d *schema.ResourceData) error {
-	if ccaError, ok := err.(api.CcaErrorResponse); ok {
-		if ccaError.StatusCode == 404 {
-			fmt.Errorf("Port forwarding rule with id %s no longer exists", d.Id())
-			d.SetId("")
-			return nil
-		}
-	}
-
-	return err
 }

--- a/cloudca/resource_cloudca_static_nat.go
+++ b/cloudca/resource_cloudca_static_nat.go
@@ -23,15 +23,8 @@ func resourceCloudcaStaticNat() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Name of environment where tier should be created",
+				Description: "Name of environment where static NAT should be enabled",
 			},
-			"organization_code": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "Entry point of organization",
-			},
-
 			"public_ip_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,

--- a/cloudca/resource_cloudca_static_nat.go
+++ b/cloudca/resource_cloudca_static_nat.go
@@ -1,0 +1,85 @@
+package cloudca
+
+import (
+	"github.com/cloud-ca/go-cloudca/services/cloudca"
+	"github.com/hashicorp/terraform/helper/schema"
+	"fmt"
+)
+
+func resourceCloudcaStaticNat() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCloudcaStaticNatCreate,
+		Read:   resourceCloudcaStaticNatRead,
+		Delete: resourceCloudcaStaticNatDelete,
+
+		Schema: map[string]*schema.Schema{
+			"service_code": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "A cloudca service code",
+			},
+			"environment_name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of environment where tier should be created",
+			},
+			"organization_code": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Entry point of organization",
+			},
+
+			"public_ip_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The public IP to enable static NAT on",
+			},
+			"private_ip_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The private IP to enable static NAT on",
+			},
+		},
+	}
+}
+
+func resourceCloudcaStaticNatCreate(d *schema.ResourceData, meta interface{}) error {
+	resources := getResources(d, meta)
+	staticNatPublicIp := cloudca.PublicIp{
+		Id:          d.Get("public_ip_id").(string),
+		PrivateIpId: d.Get("private_ip_id").(string),
+	}
+	_, err := resources.PublicIps.EnableStaticNat(staticNatPublicIp)
+	if err != nil {
+		return fmt.Errorf("Error enabling static NAT: %s", err)
+	}
+	d.SetId(staticNatPublicIp.Id)
+	return resourceCloudcaStaticNatRead(d, meta)
+}
+
+func resourceCloudcaStaticNatRead(d *schema.ResourceData, meta interface{}) error {
+	resources := getResources(d, meta)
+	publicIp, err := resources.PublicIps.Get(d.Id())
+	if err != nil {
+		return handleNotFoundError(err, d)
+	}
+	if publicIp.PrivateIpId == "" {
+		// If the private IP ID is missing, it means the public IP no longer has static NAT
+		// enabled and so this entity is "missing" (at least as far as terraform is concerned).
+		d.SetId("")
+		return nil
+	}
+	d.Set("private_ip_id", publicIp.PrivateIpId)
+	return nil
+}
+
+func resourceCloudcaStaticNatDelete(d *schema.ResourceData, meta interface{}) error {
+	resources := getResources(d, meta)
+	_, err := resources.PublicIps.DisableStaticNat(d.Id())
+	return handleNotFoundError(err, d)
+}


### PR DESCRIPTION
Also adds utility functions for 

- dealing with the casting involved in getting a `cloudca.Resources`
- dealing with CcaErrorResponse 404s
